### PR TITLE
Implement the best-effort compilation

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -30,6 +30,10 @@ main = do
       p {
         text-indent:25px;
       }
+      .error {
+        color: red;
+        background-color: black;
+      }
       .reply {
         color:gray;
       }
@@ -63,6 +67,7 @@ htmlConf :: Typography Html
 htmlConf typo =
   GenConf typo
           (\doc -> [shamlet|<article>#{doc}|])
+          (\doc -> [shamlet|<div .error>#{doc}|])
           id
           asideTemp
           (\paragraph -> [shamlet|<p>#{paragraph}|])

--- a/src/Text/Ogmarkup/Private/Ast.hs
+++ b/src/Text/Ogmarkup/Private/Ast.hs
@@ -15,6 +15,9 @@ data Component a =
     Teller [Format a]            -- ^ A narrative description
   | Dialogue (Reply a) (Maybe a) -- ^ A dialogue reply
   | Thought (Reply a) (Maybe a)  -- ^ Inner dialogue of the character.
+  | IllFormed a                  -- ^ If none of the above matched, then output
+                                 --   what follows as-is, the parsing will
+                                 --   be resumed at the next paragraph
     deriving (Eq,Show)
 
 -- | A character line of dialogue. A reply may contain a descriptive part, which

--- a/src/Text/Ogmarkup/Private/Config.hs
+++ b/src/Text/Ogmarkup/Private/Config.hs
@@ -13,6 +13,7 @@ type Template a = a -> a
 data GenConf a = GenConf { -- | The Typography to use for the generation
                          typography         :: Typography a,
                          documentTemplate   :: Template a,
+                         errorTemplate      :: Template a,
                          storyTemplate      :: Template a,
                          asideTemplate      :: Maybe a -> Template a,
                          paragraphTemplate  :: Template a,

--- a/src/Text/Ogmarkup/Private/Generator.hs
+++ b/src/Text/Ogmarkup/Private/Generator.hs
@@ -183,6 +183,9 @@ component p n (Ast.Thought d a) = do
 
   apply (temp $ auth a) (reply Nothing Nothing d)
 component p n (Ast.Teller fs) = formats fs
+component p n (Ast.IllFormed ws) = do
+    temp <- askConf errorTemplate
+    apply temp (raw ws)
 
 -- | Process a 'Ast.Paragraph' and deal with sequence of 'Ast.Reply'.
 paragraph :: Monoid a

--- a/test/GeneratorSpec.hs
+++ b/test/GeneratorSpec.hs
@@ -30,6 +30,7 @@ spec = do describe "format" $ do
 testConf :: GenConf Text
 testConf = GenConf frenchTypo
                    (\ doc        -> [st|[doc]#{doc}[/doc]|])
+                   (\ doc        -> [st|[error]#{doc}[/error]|])
                    (\ story      -> [st|[story]#{story}[/story]|])
                    (\ cls aside  -> case cls of
                                       Just c  -> [st|[aside-#{c}]#{aside}[/aside-#{c}]|]

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -43,6 +43,14 @@ spec = do
         Parser.parse (Parser.reply '[' ']') "" dialogStartingWithSpaceStr `shouldParse` dialogStartingWithSpaceReply
         Parser.parse (Parser.reply '[' ']') "" clauseStartingWithSpaceStr `shouldParse` clauseStartingWithSpaceReply
 
+    describe "ill-formed paragraphs" $ do
+      it "ill-formed components should be accepted as-is" $ do
+        Parser.parse Parser.component "" illQuoteStr  `shouldParse` Ast.IllFormed illQuoteStr
+        Parser.parse Parser.component "" nestedEmphStr  `shouldParse` Ast.IllFormed nestedEmphStr
+        Parser.parse Parser.component "" nestedStrongEmphStr  `shouldParse` Ast.IllFormed nestedStrongEmphStr
+      it "an ill-formed paragraph should not prevent parsing correctly the others" $ do
+        Parser.parse Parser.story "" secondParagraphIllFormed `shouldParse` secondParagraphIllFormedPartialCompilation
+
 hiStr = "hi"
 hiAtom = Ast.Word "hi"
 
@@ -76,3 +84,9 @@ clauseStartingWithSpaceReply  = Ast.WithSay [  Ast.Raw [hiAtom] ]
                                             ]
                                             [ ]
 
+secondParagraphIllFormed = hiStr ++ "\n\n" ++ illQuoteStr ++ "\n\n" ++ hiStr
+secondParagraphIllFormedPartialCompilation =
+    Ast.Story [ [ Ast.Teller [ Ast.Raw [ hiAtom ] ] ]
+              , [ Ast.IllFormed illQuoteStr ]
+              , [ Ast.Teller [ Ast.Raw [ hiAtom ] ] ]
+              ]


### PR DESCRIPTION
The compilation is paragraph-based. An ill-formed paragraph is output as-is, with a template called 'errorTemplate' in the configuration.

A problem caused by this patch is that we lose the precise location of errors.

Addresses #19 