### PR TITLE
With best-effort compilation, ogmarkup becomes total

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,7 +17,8 @@ import Text.Blaze.Html (preEscapedToHtml)
 main :: IO ()
 main = do
   input <- readFile "examples/sample.up"
-  let res = ogmarkup input HtmlConf
+  let res = ogmarkup ByLine input HtmlConf
+      res' = ogmarkup ByChar input HtmlConf
 
   putStrLn $ renderHtml [shamlet|$doctype 5
 <html>
@@ -47,7 +48,10 @@ main = do
         font-style: italic;
       }
   <body>
-    #{res}|]
+    <div>
+      #{res}
+    <div>
+      #{res'}|]
 
 data HtmlConf = HtmlConf
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,8 +17,9 @@ import Text.Blaze.Html (preEscapedToHtml)
 main :: IO ()
 main = do
   input <- readFile "examples/sample.up"
-  case ogmarkup input HtmlConf of
-    Right res -> putStrLn $ renderHtml [shamlet|$doctype 5
+  let res = ogmarkup input HtmlConf
+
+  putStrLn $ renderHtml [shamlet|$doctype 5
 <html>
   <head>
     <meta charset=utf-8>
@@ -47,7 +48,6 @@ main = do
       }
   <body>
     #{res}|]
-    Left err -> print err
 
 data HtmlConf = HtmlConf
 

--- a/src/Text/Ogmarkup.hs
+++ b/src/Text/Ogmarkup.hs
@@ -32,9 +32,9 @@ import qualified Text.Ogmarkup.Private.Typography as Typo
 ogmarkup :: (IsString a, Monoid a, Conf.GenConf c a)
          => String
          -> c
-         -> Either ParseError a
+         -> a
 ogmarkup input conf = let res = Parser.parse Parser.document
                                              ""
                                              input
-                      in case res of Right ast -> Right $ Gen.runGenerator (Gen.document ast) conf
-                                     Left err -> Left err
+                      in case res of Right ast -> Gen.runGenerator (Gen.document ast) conf
+                                     Left err -> error $ show err

--- a/src/Text/Ogmarkup.hs
+++ b/src/Text/Ogmarkup.hs
@@ -23,12 +23,16 @@ import           Data.List
 import           Text.ParserCombinators.Parsec
 import           Data.Monoid
 
-import qualified Text.Ogmarkup.Private.Config            as Conf
-import qualified Text.Ogmarkup.Private.Ast       as Ast
-import qualified Text.Ogmarkup.Private.Generator as Gen
-import qualified Text.Ogmarkup.Private.Parser    as Parser
+import qualified Text.Ogmarkup.Private.Config     as Conf
+import qualified Text.Ogmarkup.Private.Ast        as Ast
+import qualified Text.Ogmarkup.Private.Generator  as Gen
+import qualified Text.Ogmarkup.Private.Parser     as Parser
 import qualified Text.Ogmarkup.Private.Typography as Typo
 
+-- | With the best-effort compilation feature of ogmarkup, when the parser
+--   encounters an error, it can apply two different strategies with the
+--   remaining input to find a new synchronization point. It can search
+--   character by character or line by line.
 data Strategy =
     ByLine
   | ByChar

--- a/src/Text/Ogmarkup.hs
+++ b/src/Text/Ogmarkup.hs
@@ -1,6 +1,7 @@
 module Text.Ogmarkup
     (
       -- * Parse and Generate
+      Strategy (..),
       ogmarkup,
 
       -- * Generation Configuration
@@ -18,7 +19,9 @@ module Text.Ogmarkup
     ) where
 
 import           Data.String
+import           Data.List
 import           Text.ParserCombinators.Parsec
+import           Data.Monoid
 
 import qualified Text.Ogmarkup.Private.Config            as Conf
 import qualified Text.Ogmarkup.Private.Ast       as Ast
@@ -26,15 +29,47 @@ import qualified Text.Ogmarkup.Private.Generator as Gen
 import qualified Text.Ogmarkup.Private.Parser    as Parser
 import qualified Text.Ogmarkup.Private.Typography as Typo
 
+data Strategy =
+    ByLine
+  | ByChar
+
 -- | From a String, parse and generate an output according to a generation configuration.
 --   The inner definitions of the parser and the generator implies the output
 --   type has to be an instance of the 'IsString' and 'Monoid' classes.
 ogmarkup :: (IsString a, Monoid a, Conf.GenConf c a)
-         => String
-         -> c
+         => Strategy       -- ^ Best-effort compilation strategy
+         -> String         -- ^ The input string
+         -> c              -- ^ The generator configuration
          -> a
-ogmarkup input conf = let res = Parser.parse Parser.document
-                                             ""
-                                             input
-                      in case res of Right ast -> Gen.runGenerator (Gen.document ast) conf
-                                     Left err -> error $ show err
+ogmarkup be input conf = Gen.runGenerator (Gen.document (_ogmarkup be "" input [])) conf
+  where
+    _ogmarkup :: (IsString a, Monoid a)
+              => Strategy -- best-effort compilation strategy
+              -> String   -- acc
+              -> String   -- input
+              -> Ast.Document a
+              -> Ast.Document a
+
+    _ogmarkup _ "" "" ast = ast
+
+    _ogmarkup _ acc "" ast = ast `mappend` [Ast.Failing . fromString $ acc]
+
+    _ogmarkup be acc input ast =
+      case Parser.parse Parser.document "" input of
+        Right (ast', input') ->
+          if input == input'  -- nothing has been parsed
+          then let (c, rst) = applyStrat be input
+               in _ogmarkup be (acc `mappend` c) rst ast
+          else if acc == ""
+               then _ogmarkup be [] input' (ast `mappend` ast')
+               else let f = Ast.Failing . fromString $ acc
+                    in _ogmarkup be [] input' (ast `mappend` (f:ast'))
+        Left err -> error $ show err
+
+    applyStrat :: Strategy
+               -> String
+               -> (String, String)
+
+    applyStrat _ [] = ([], [])
+    applyStrat ByLine input = break (== '\n') input
+    applyStrat ByChar (c:rst) = ([c], rst)

--- a/src/Text/Ogmarkup/Private/Ast.hs
+++ b/src/Text/Ogmarkup/Private/Ast.hs
@@ -7,6 +7,7 @@ type Document a = [Section a]
 data Section a =
     Story [Paragraph a]           -- ^ The story as it goes
   | Aside (Maybe a) [Paragraph a] -- ^ Something else. Maybe a letter, a flashback, etc.
+  | Failing a
     deriving (Eq,Show)
 
 type Paragraph a = [Component a]

--- a/src/Text/Ogmarkup/Private/Generator.hs
+++ b/src/Text/Ogmarkup/Private/Generator.hs
@@ -237,6 +237,11 @@ section (Ast.Story ps) = do temp <- askConf storyTemplate
 section (Ast.Aside cls ps) = do temp <- askConf asideTemplate
                                 apply (temp cls) (paragraphs ps)
 
+section (Ast.Failing f) = do
+    temp <- askConf errorTemplate
+    temp2 <- askConf storyTemplate
+    apply (temp2 . temp) (raw f)
+
 -- | Process a sequence of 'Ast.Section'.
 sections :: (Monoid a, GenConf c a)
          => [Ast.Section a]

--- a/src/Text/Ogmarkup/Private/Parser.hs
+++ b/src/Text/Ogmarkup/Private/Parser.hs
@@ -83,7 +83,10 @@ withStrongEmph = parseWithStrongEmph <$> getState
 withinQuote :: OgmarkupParser Bool
 withinQuote = parseWithinQuote <$> getState
 
--- | See 'Ast.Document'.
+-- | Try its best to parse an ogmarkup document. When it encounters an
+--   error, it returns an Ast and the remaining input.
+--
+--   See 'Ast.Document'.
 document :: IsString a
          => OgmarkupParser (Ast.Document a, String)
 document = do spaces

--- a/src/Text/Ogmarkup/Private/Parser.hs
+++ b/src/Text/Ogmarkup/Private/Parser.hs
@@ -85,12 +85,12 @@ withinQuote = parseWithinQuote <$> getState
 
 -- | See 'Ast.Document'.
 document :: IsString a
-         => OgmarkupParser (Ast.Document a)
+         => OgmarkupParser (Ast.Document a, String)
 document = do spaces
-              sects <- many1 section
-              eof
+              sects <- many (try section)
+              input <- getInput
 
-              return sects
+              return (sects, input)
 
 -- | See 'Ast.Section'.
 section :: IsString a

--- a/test/ParserSpec.hs
+++ b/test/ParserSpec.hs
@@ -51,6 +51,10 @@ spec = do
       it "an ill-formed paragraph should not prevent parsing correctly the others" $ do
         Parser.parse Parser.story "" secondParagraphIllFormed `shouldParse` secondParagraphIllFormedPartialCompilation
 
+    describe "document" $ do
+      it "should try its best to compile an ill-formed document" $ do
+        Parser.parse Parser.document "" (storyStr ++ "\n\n" ++ asideIllFormed) `shouldParse` ([storyAst], asideIllFormed)
+
 hiStr = "hi"
 hiAtom = Ast.Word "hi"
 
@@ -90,3 +94,8 @@ secondParagraphIllFormedPartialCompilation =
               , [ Ast.IllFormed illQuoteStr ]
               , [ Ast.Teller [ Ast.Raw [ hiAtom ] ] ]
               ]
+
+storyStr = hiStr
+storyAst = Ast.Story [ [ Ast.Teller [ Ast.Raw [ hiAtom ] ] ] ]
+
+asideIllFormed = "_______letter______\n\n_______letter______\n\nTest.\n\n____________"


### PR DESCRIPTION
This is a quick proposal. From my point of view and now that we have a best-effort compilation with errors that are embedded within the output, if ogmarkup fails then we have a bug. Therefore, we should assume ogmarkup is a total functions that always returns something.