### PR TITLE
Update ogmarkup dependencies

### DIFF
--- a/ogmarkup.cabal
+++ b/ogmarkup.cabal
@@ -27,7 +27,7 @@ library
         Text.Ogmarkup.Private.Config
     build-depends:
         base >=4.7 && <5,
-        parsec ==3.1.9,
+        parsec ==3.1.*,
         mtl -any
     default-language: Haskell2010
     hs-source-dirs: src

--- a/stack.yaml
+++ b/stack.yaml
@@ -2,4 +2,4 @@ flags: {}
 extra-package-dbs: []
 packages:
 - '.'
-resolver: lts-5.4
+resolver: nightly-2016-07-29


### PR DESCRIPTION
This PR does two things:

* It updates the snapshot used by stack to the latest available (`nightly`); as a consequences, when using `stack build`, it uses ghc-8.1.
* It uses a more relax version constrain for parsec

**QA:** travis should be enough, it does not add or remove any haskell lines